### PR TITLE
#12: Puppeteer tasks script does not wait for tasks list (closes #12)

### DIFF
--- a/paper-tasks-puppeteer/README.md
+++ b/paper-tasks-puppeteer/README.md
@@ -11,7 +11,7 @@ You can click on the count to show the link to open the Dropbox Paper tasks page
 ## Prerequisites
 - [BitBar](https://github.com/matryer/bitbar) (if you use brew cask: `brew cask install bitbar`)
 - [node](https://nodejs.org/) (`brew install node`)
-- [puppeteer](https://github.com/GoogleChrome/puppeteer) (`npm install -g puppeteer`)
+- [puppeteer@0.13](https://github.com/GoogleChrome/puppeteer) (`npm install -g puppeteer@0.13`)
 
 ## Installation
 - copy the script in the BitBar plugin directory

--- a/paper-tasks-puppeteer/paper-tasks-puppeteer.2m.js
+++ b/paper-tasks-puppeteer/paper-tasks-puppeteer.2m.js
@@ -3,12 +3,17 @@
 /******** CONFIGURATION ********/
 const email = '<NAME.LASTNAME>@buildo.io' // Your dropbox email, e.g. francesco@buildo.io
 const password = '<PASSWORD>' // your dropbox password
-const puppeteerPath = '/path/to/puppeteer' // e.g. /usr/local/lib/node_modules/puppeteer
+const puppeteerPath = '/path/to/puppeteer' // path to the puppeteer@0.13 node module folder e.g. /usr/local/lib/node_modules/puppeteer
 const puppeteerDataDir = '/path/to/bitbar/plugins/.puppeteer' // path to the puppeteer's userDataDir, used to persist login sessions
 const headless = true // should always be 'true'. Set to false for debugging and first-time 2FA login
 /*************** ***************/
 
 const puppeteer = require(puppeteerPath)
+const version = require(`${puppeteerPath}/package.json`).version
+if (version !== "0.13.0") {
+  console.error("Wrong puppeteer version: use puppeteer@0.13.0")
+  process.exit(1);
+}
 
 // global variable is needed to call "browser.close()" when script is over
 let browser

--- a/paper-tasks-puppeteer/paper-tasks-puppeteer.2m.js
+++ b/paper-tasks-puppeteer/paper-tasks-puppeteer.2m.js
@@ -9,7 +9,7 @@ const headless = true // should always be 'true'. Set to false for debugging and
 /*************** ***************/
 
 const puppeteer = require(puppeteerPath)
-const version = require(`${puppeteerPath}/package.json`).version
+const version = require(`${puppeteerPath.replace(/\/$/, "")}/package.json`).version
 if (version !== "0.13.0") {
   console.error("Wrong puppeteer version: use puppeteer@0.13.0")
   process.exit(1);

--- a/paper-tasks-puppeteer/paper-tasks-puppeteer.2m.js
+++ b/paper-tasks-puppeteer/paper-tasks-puppeteer.2m.js
@@ -36,7 +36,8 @@ async function getPaperTasks() {
   }
 
   // navigate to tasks page
-  await page.goto('https://paper.dropbox.com/tasks', { waitUntil: 'networkidle2' })
+  await page.goto('https://paper.dropbox.com/tasks')
+  await page.waitForSelector('.hp-tasks-list')
 
   // collect tasks
   const taskElements = await page.$$('.hp-task')


### PR DESCRIPTION
Closes #12

## Test Plan

Tested locally, it works with `puppeteer` `0.13`.

However, it seems to be broken on `puppeteer` `1.0.0`, because of this: https://github.com/GoogleChrome/puppeteer/issues/1229