### PR TITLE
#17: Paper tasks: skip login step does not always work (closes #17)

### DIFF
--- a/paper-tasks-puppeteer/paper-tasks-puppeteer.2m.js
+++ b/paper-tasks-puppeteer/paper-tasks-puppeteer.2m.js
@@ -29,8 +29,8 @@ async function getPaperTasks() {
 
   // navigate to dropbox login page
   const loginPage = await page.goto('https://www.dropbox.com/login')
-  // skip the login if we've been redirected to the home page (i.e. we're already logged in)
-  if (!page.url().endsWith('/h')) {
+  // skip the login if we've been redirected (i.e. we're already logged in)
+  if (page.url().endsWith('/login')) {
     await page.waitForSelector('input[type="email"]')
 
     // fill login form and login


### PR DESCRIPTION
Closes #17

## Test Plan

Fixed: in my case after the redirect (since already logged in) `page.url()` was just `https://www.dropbox.com/`, not ending with `/h`.

### tests performed
The plugin still works.
