### PR TITLE
#22: Assigned Issues not work

### DIFF
--- a/assigned-issues/assigned-issues.2m.sh
+++ b/assigned-issues/assigned-issues.2m.sh
@@ -15,7 +15,7 @@ GITHUB_COM_RESULT=`curl -ks $GITHUB_COM_API/search/issues\?q\=$QUERY\&access_tok
 
 GITHUB_COM_COUNT=`echo $GITHUB_COM_RESULT | jq '.total_count'`
 
-COUNT$GITHUB_COM_COUNT
+COUNT=$GITHUB_COM_COUNT
 
 case $BitBarDarkMode in
   1) ICON_URL=http://s16.postimg.org/47oxw1dg1/issue_icon_white.png ;;


### PR DESCRIPTION
Closes [#2520356](https://buildo.kaiten.io/space/32111/card/2520356)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #22

## Test Plan

### tests performed
After bitbar refresh correct issues's number is showed
